### PR TITLE
Setup: dependencies, Drizzle config, and DB schema

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,0 +1,76 @@
+import { sql } from "drizzle-orm";
+import {
+  bigserial,
+  check,
+  date,
+  doublePrecision,
+  integer,
+  jsonb,
+  pgEnum,
+  pgTable,
+  real,
+  text,
+  timestamp,
+  uuid,
+} from "drizzle-orm/pg-core";
+
+// Enum for the fog-of-war computation lifecycle
+export const fogStatusEnum = pgEnum("fog_status", [
+  "pending",
+  "processing",
+  "complete",
+  "error",
+]);
+
+// Auth stub — keeps the schema auth-ready without requiring a full auth system yet
+export const users = pgTable("users", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  email: text("email").notNull(),
+  created_at: timestamp("created_at", { withTimezone: true }).defaultNow(),
+});
+
+// One hike per GPX upload; bbox enables spatial filtering without loading track points
+export const hikes = pgTable(
+  "hikes",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    user_id: uuid("user_id")
+      .notNull()
+      .references(() => users.id),
+    name: text("name").notNull(),
+    date: date("date"),
+    // [minLng, minLat, maxLng, maxLat] — real(4) matches float4[] in Postgres
+    bbox: real("bbox").array(4),
+    stats: jsonb("stats"),
+    fog_status: fogStatusEnum("fog_status").default("pending"),
+    fog_geojson: jsonb("fog_geojson"),
+    created_at: timestamp("created_at", { withTimezone: true }).defaultNow(),
+  },
+  (table) => [
+    check(
+      "fog_status_check",
+      sql`${table.fog_status} in ('pending', 'processing', 'complete', 'error')`
+    ),
+  ]
+);
+
+// Individual rows (not JSONB array) so track points can be streamed during viewshed computation
+export const trackPoints = pgTable("track_points", {
+  id: bigserial("id", { mode: "number" }).primaryKey(),
+  hike_id: uuid("hike_id")
+    .notNull()
+    .references(() => hikes.id),
+  seq: integer("seq").notNull(),
+  lat: doublePrecision("lat").notNull(),
+  lng: doublePrecision("lng").notNull(),
+  elevation: doublePrecision("elevation").notNull(),
+  timestamp: timestamp("timestamp", { withTimezone: true }),
+});
+
+// Per-user visualisation settings; expands to a full preferences store later
+export const userPreferences = pgTable("user_preferences", {
+  user_id: uuid("user_id")
+    .primaryKey()
+    .references(() => users.id),
+  viz_preferences: jsonb("viz_preferences"),
+});


### PR DESCRIPTION
## Summary

- Install `drizzle-orm`, `drizzle-kit`, `postgres`, `@supabase/supabase-js`, `daisyui` v5, `@tailwindcss/typography`
- Configure DaisyUI and typography via `@plugin` in `globals.css` (Tailwind v4 convention — no `tailwind.config.ts`)
- Add `drizzle.config.ts` pointing to `src/db/schema.ts` with `DATABASE_URL`
- Add `src/db/index.ts` — Drizzle client using the `postgres` driver
- Add `src/db/schema.ts` — four tables: `users`, `hikes`, `track_points`, `user_preferences`

## Schema notes

- `fog_status` uses a `pgEnum` + redundant `CHECK` constraint
- `bbox` is `real[4]` (`float4[]`) — `[minLng, minLat, maxLng, maxLat]`
- `track_points` stored as individual rows (not JSONB array) for streamable viewshed computation
- Auth is stubbed via `users` table — swapping in real auth later requires zero migration

## Test plan

- [ ] `pnpm exec tsc --noEmit` passes
- [ ] `DATABASE_URL` added to `.env.local` (Supabase connection string)
- [ ] `pnpm drizzle-kit generate` produces valid SQL migration files
- [ ] Tables visible in Supabase dashboard after `pnpm drizzle-kit migrate`

https://claude.ai/code/session_01UL4hf1sMYk58yTv7EJd3fS