### PR TITLE
chore: add Claude Code tool permissions to settings.local.json

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,15 @@
       "Read(//c/Program Files/**)",
       "Read(//c/Users/juanp/AppData/Local/Programs/**)",
       "Read(//c/Users/juanp/AppData/Local/**)",
-      "Bash(powershell.exe:*)"
+      "Bash(powershell.exe:*)",
+      "Read(//c/ProgramData/chocolatey/bin/**)",
+      "Bash(ls \"/c/Program Files/GitHub CLI/\"*)",
+      "Bash(cmd /c \"where gh 2>nul\")",
+      "Bash(cmd /c \"git config --global credential.helper\")",
+      "Bash(cmd /c \"git config --list | findstr credential\")",
+      "Bash(git config:*)",
+      "Bash(printf \"protocol=https\\\\nhost=github.com\\\\n\")",
+      "Bash(git credential:*)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Adds tool permission entries to `.claude/settings.local.json` accumulated during the GitHub issue creation session

## Test plan
- [ ] No functional code changed; verify settings file looks correct

?? Generated with [Claude Code](https://claude.com/claude-code)