### PR TITLE
feat: GPX storage upload, RLS policies, and secure server actions

### DIFF
--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -82,7 +82,20 @@ export default function TestPage() {
       payload.date = formDate || null;
       payload.stats.creator = formCreator.trim() || payload.stats.creator;
 
-      const result = await saveHike(payload, user.id);
+      // upload original GPX to storage — path: {userId}/{uuid}.gpx
+      const storagePath = `${user.id}/${crypto.randomUUID()}.gpx`;
+      const { error: storageError } = await supabase.storage
+        .from("gpx-files")
+        .upload(storagePath, file, { contentType: "application/gpx+xml" });
+
+      if (storageError) {
+        setSubmitResult({ success: false, error: `Storage upload failed: ${storageError.message}` });
+        return;
+      }
+
+      payload.gpxStoragePath = storagePath;
+
+      const result = await saveHike(payload);
       setSubmitResult(result);
       if (result.success) {
         router.push("/user");

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -57,6 +57,10 @@ export const hikes = pgTable(
     start_time: timestamp("start_time", { withTimezone: true }),
     end_time: timestamp("end_time", { withTimezone: true }),
 
+    // ── original GPX file ──────────────────────────────────────────────────
+    // path within the "gpx-files" Supabase Storage bucket
+    gpx_storage_path: text("gpx_storage_path"),
+
     // ── catch-all for future unstructured metadata ──────────────────────────
     // e.g. historical weather, user notes, terrain tags
     extra: jsonb("extra"),

--- a/drizzle/0002_dashing_mesmero.sql
+++ b/drizzle/0002_dashing_mesmero.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "track_points" DROP CONSTRAINT "track_points_hike_id_hikes_id_fk";
+--> statement-breakpoint
+ALTER TABLE "hikes" ADD COLUMN "gpx_storage_path" text;--> statement-breakpoint
+ALTER TABLE "track_points" ADD CONSTRAINT "track_points_hike_id_hikes_id_fk" FOREIGN KEY ("hike_id") REFERENCES "public"."hikes"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,303 @@
+{
+  "id": "3a736350-a2c6-4ddd-96e2-b294eb25e833",
+  "prevId": "ab8b6eed-70d5-4f9c-9c20-297aa1f53ad5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.hikes": {
+      "name": "hikes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox": {
+          "name": "bbox",
+          "type": "real[4]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator": {
+          "name": "creator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distance_km": {
+          "name": "distance_km",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "elevation_gain_m": {
+          "name": "elevation_gain_m",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpx_storage_path": {
+          "name": "gpx_storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fog_status": {
+          "name": "fog_status",
+          "type": "fog_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "fog_geojson": {
+          "name": "fog_geojson",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hikes_user_id_users_id_fk": {
+          "name": "hikes_user_id_users_id_fk",
+          "tableFrom": "hikes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "fog_status_check": {
+          "name": "fog_status_check",
+          "value": "\"hikes\".\"fog_status\" in ('pending', 'processing', 'complete', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.track_points": {
+      "name": "track_points",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hike_id": {
+          "name": "hike_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "elevation": {
+          "name": "elevation",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "track_points_hike_id_hikes_id_fk": {
+          "name": "track_points_hike_id_hikes_id_fk",
+          "tableFrom": "track_points",
+          "tableTo": "hikes",
+          "columnsFrom": [
+            "hike_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "viz_preferences": {
+          "name": "viz_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.fog_status": {
+      "name": "fog_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "complete",
+        "error"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776048322319,
       "tag": "0001_brown_red_shift",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1776224159996,
+      "tag": "0002_dashing_mesmero",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/hike-actions.ts
+++ b/lib/hike-actions.ts
@@ -23,12 +23,23 @@ async function getCurrentUser() {
 
 export async function saveHike(
   payload: ParsedHikePayload,
-  userId: string,
 ): Promise<UploadResult> {
+  const user = await getCurrentUser();
+  if (!user) return { success: false, error: "Not authenticated" };
+
   if (payload.trackPoints.length === 0) {
     return { success: false, error: "GPX file contains no track points" };
   }
 
+  // Ensure the storage path (if provided) belongs to this user's folder
+  if (
+    payload.gpxStoragePath &&
+    !payload.gpxStoragePath.startsWith(`${user.id}/`)
+  ) {
+    return { success: false, error: "Invalid storage path" };
+  }
+
+  const userId = user.id;
   const { stats } = payload;
 
   const [hike] = await db
@@ -44,6 +55,7 @@ export async function saveHike(
       duration_seconds: stats.durationSeconds ?? undefined,
       start_time: stats.startTime ? new Date(stats.startTime) : undefined,
       end_time: stats.endTime ? new Date(stats.endTime) : undefined,
+      gpx_storage_path: payload.gpxStoragePath ?? null,
     })
     .returning({ id: hikes.id });
 
@@ -68,18 +80,33 @@ export async function saveHike(
 export async function deleteHike(
   hikeId: string,
 ): Promise<{ success: boolean; error?: string }> {
-  const user = await getCurrentUser();
+  // Use one client for both auth and storage so the same session token is used
+  const cookieStore = await cookies();
+  const supabase = createClient(cookieStore);
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
   if (!user) return { success: false, error: "Not authenticated" };
 
-  // Verify ownership before deleting anything
-  const owned = await db
-    .select({ id: hikes.id })
+  // Verify ownership and fetch the storage path in one query
+  const [owned] = await db
+    .select({ id: hikes.id, gpx_storage_path: hikes.gpx_storage_path })
     .from(hikes)
     .where(and(eq(hikes.id, hikeId), eq(hikes.user_id, user.id)))
     .limit(1);
 
-  if (owned.length === 0) {
+  if (!owned) {
     return { success: false, error: "Hike not found" };
+  }
+
+  // Remove GPX file from storage before deleting the DB record
+  if (owned.gpx_storage_path) {
+    const { error: storageError } = await supabase.storage
+      .from("gpx-files")
+      .remove([owned.gpx_storage_path]);
+    if (storageError) {
+      return { success: false, error: `Failed to delete file: ${storageError.message}` };
+    }
   }
 
   // Delete child rows first — guard against DB constraints that lack ON DELETE CASCADE

--- a/supabase/migrations/20260414_rls_policies.sql
+++ b/supabase/migrations/20260414_rls_policies.sql
@@ -1,0 +1,89 @@
+-- ══════════════════════════════════════════════════════════════════════════════
+--  Row Level Security policies
+--  Applied 2026-04-14 via Supabase MCP.
+--  Run this file against your local Supabase instance to mirror production.
+--
+--  Design notes
+--  ─────────────
+--  • All tables already have RLS enabled (rowsecurity = true).
+--  • The postgres/service-role connection used by Drizzle server actions bypasses
+--    RLS entirely — manual ownership checks in those actions are the primary guard.
+--  • These policies protect direct Supabase JS client access (anon / authenticated
+--    role) and act as a second layer of defence.
+--  • Storage bucket "gpx-files" policies are managed separately in the Supabase
+--    dashboard (SELECT/INSERT/DELETE/UPDATE already restricted to owner folder).
+-- ══════════════════════════════════════════════════════════════════════════════
+
+-- ── users ─────────────────────────────────────────────────────────────────────
+-- Read own profile only. Inserts are done server-side via service role.
+CREATE POLICY "users_select_own"
+  ON public.users FOR SELECT TO authenticated
+  USING (id = auth.uid());
+
+-- ── hikes ─────────────────────────────────────────────────────────────────────
+CREATE POLICY "hikes_select_own"
+  ON public.hikes FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY "hikes_insert_own"
+  ON public.hikes FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "hikes_update_own"
+  ON public.hikes FOR UPDATE TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "hikes_delete_own"
+  ON public.hikes FOR DELETE TO authenticated
+  USING (user_id = auth.uid());
+
+-- ── track_points ──────────────────────────────────────────────────────────────
+-- Access is gated through ownership of the parent hike.
+CREATE POLICY "track_points_select_own"
+  ON public.track_points FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.hikes
+      WHERE hikes.id = track_points.hike_id
+        AND hikes.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "track_points_insert_own"
+  ON public.track_points FOR INSERT TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.hikes
+      WHERE hikes.id = track_points.hike_id
+        AND hikes.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "track_points_delete_own"
+  ON public.track_points FOR DELETE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.hikes
+      WHERE hikes.id = track_points.hike_id
+        AND hikes.user_id = auth.uid()
+    )
+  );
+
+-- ── user_preferences ──────────────────────────────────────────────────────────
+CREATE POLICY "user_preferences_select_own"
+  ON public.user_preferences FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY "user_preferences_insert_own"
+  ON public.user_preferences FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "user_preferences_update_own"
+  ON public.user_preferences FOR UPDATE TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "user_preferences_delete_own"
+  ON public.user_preferences FOR DELETE TO authenticated
+  USING (user_id = auth.uid());

--- a/types/hike-upload.ts
+++ b/types/hike-upload.ts
@@ -34,6 +34,7 @@ export interface ParsedHikePayload {
   bbox: [number, number, number, number] | null;
   trackPoints: ParsedTrackPoint[];
   stats: HikeStats;
+  gpxStoragePath?: string;
 }
 
 export type UploadResult =


### PR DESCRIPTION
## Summary

- **GPX file storage**: Hike uploads now persist the original `.gpx` file to the `gpx-files` Supabase Storage bucket at `{userId}/{uuid}.gpx` and store the path in the new `gpx_storage_path` column. Deleting a hike removes the file first.
- **Row Level Security**: 12 RLS policies applied to `hikes`, `track_points`, `users`, and `user_preferences` — all scoped to the `authenticated` role and enforcing `auth.uid()` ownership. A reference SQL file is added at `supabase/migrations/20260414_rls_policies.sql`.
- **Server action hardening**: `saveHike` no longer trusts the `userId` passed from the client — it derives the user from the server session and validates the storage path prefix. `deleteHike` now uses a single Supabase client for both auth and the storage remove call (fixes a session token inconsistency), and surfaces storage errors instead of silently swallowing them.

## Schema changes

`drizzle/0002_dashing_mesmero.sql` adds `gpx_storage_path text` to `hikes` and updates the `track_points` FK to `ON DELETE CASCADE`. This migration has already been applied to the Supabase project.

## Test plan

- [ ] Upload a `.gpx` file on `/test` — confirm hike appears in `/user` and file is visible in the Supabase Storage `gpx-files` bucket under `{userId}/`
- [ ] Delete the hike from `/user` — confirm the DB row and the storage file are both removed
- [ ] Attempt to delete a hike owned by a different user (tamper the hikeId) — confirm `"Hike not found"` is returned
- [ ] Confirm the `/user` page loads correctly for an authenticated user (RLS policies allow reads via Drizzle service-role connection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)